### PR TITLE
Remove extra `=` for worker code.

### DIFF
--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -54,7 +54,7 @@ export function worker(): Plugin {
         `
       } else {
         return `
-          let myWorker = = new Worker(${file}, ${JSON.stringify({
+          let myWorker = new Worker(${file}, ${JSON.stringify({
           type: buildType === "iife" ? "classic" : "module",
         })})
           export default myWorker


### PR DESCRIPTION
My builds failed with an error in the outputted code. This seems to be the cause.