### PR TITLE
Fix promises

### DIFF
--- a/src/worker/serviceWorker.ts
+++ b/src/worker/serviceWorker.ts
@@ -21,10 +21,10 @@ export function serviceWorker(filename: string): Plugin {
 
       return SERVICE_WORKER_SCHEMA + realID.id;
     },
-    load(id) {
+    async load(id) {
       if (!id.startsWith(SERVICE_WORKER_SCHEMA)) return;
 
-      const url = bundle(
+      const url = await bundle(
         this,
         id.slice(SERVICE_WORKER_SCHEMA.length),
         "worker@service",

--- a/src/worklets/animation.ts
+++ b/src/worklets/animation.ts
@@ -29,11 +29,11 @@ export function animation(inline_worklet_animation: boolean): Plugin {
 
       return ANIMATION_WORKLET_SCHEMA + realID.id;
     },
-    load(id) {
+    async load(id) {
       if (id === ANIMATION_WORKLET_HELPER) return ANIMATION_WORKLET_HELPER_CODE;
       if (!id.startsWith(ANIMATION_WORKLET_SCHEMA)) return;
 
-      const url = bundle(
+      const url = await bundle(
         this,
         id.slice(ANIMATION_WORKLET_SCHEMA.length),
         "worklet@animation",

--- a/src/worklets/audio.ts
+++ b/src/worklets/audio.ts
@@ -31,11 +31,11 @@ export function audio(inline_worklet_audio: boolean): Plugin {
 
       return AUDIO_WORKLET_SCHEMA + realID.id;
     },
-    load(id) {
+    async load(id) {
       if (id === AUDIO_WORKLET_HELPER) return AUDIO_WORKLET_HELPER_CODE;
       if (!id.startsWith(AUDIO_WORKLET_SCHEMA)) return;
 
-      const url = bundle(
+      const url = await bundle(
         this,
         id.slice(AUDIO_WORKLET_SCHEMA.length),
         "worklet@audio",

--- a/src/worklets/layout.ts
+++ b/src/worklets/layout.ts
@@ -29,11 +29,11 @@ export function layout(inline_worklet_layout: boolean): Plugin {
 
       return LAYOUT_WORKLET_SCHEMA + realID.id;
     },
-    load(id) {
+    async load(id) {
       if (id === LAYOUT_WORKLET_HELPER) return LAYOUT_WORKLET_HELPER_CODE;
       if (!id.startsWith(LAYOUT_WORKLET_SCHEMA)) return;
 
-      const url = bundle(
+      const url = await bundle(
         this,
         id.slice(LAYOUT_WORKLET_SCHEMA.length),
         "worklet@layout",

--- a/src/worklets/paint.ts
+++ b/src/worklets/paint.ts
@@ -29,11 +29,11 @@ export function paint(inline_worklet_paint: boolean): Plugin {
 
       return PAINT_WORKLET_SCHEMA + realID.id;
     },
-    load(id) {
+    async load(id) {
       if (id === PAINT_WORKLET_HELPER) return PAINT_WORKLET_HELPER_CODE;
       if (!id.startsWith(PAINT_WORKLET_SCHEMA)) return;
 
-      const url = bundle(
+      const url = await bundle(
         this,
         id.slice(PAINT_WORKLET_SCHEMA.length),
         "worklet@paint",


### PR DESCRIPTION
This pull request adds `await`s where you forgot to put them. Currently, the code
```ts
// src/worker/serviceWorker.ts
const url = bundle(
  // ...
);

return `
  export default (opt = {}) => {
    if('serviceWorker' in navigator) {
      return navigator.serviceWorker.register(${url}, opt)
    }
  }
`;
```
puts `[object Promise]` in the place of `${url}`, because `bundle()` returns a `Promise<string>`.